### PR TITLE
Updated the IntercomClient to use Access Tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,7 @@ Change your default settings in `app/config/intercom.php`:
 ```php
 <?php
 return [
-    'app_id' => env('INTERCOM_APP_ID', '****'),
-    'api_key' => env('INTERCOM_API_KEY', '********'),
+    'access_token' => env('INTERCOM_ACCESS_TOKEN', '****'),
 ];
 ```
 

--- a/config/intercom.php
+++ b/config/intercom.php
@@ -1,6 +1,5 @@
 <?php
 
 return [
-    'app_id' => env('INTERCOM_APP_ID'),
-    'api_key' => env('INTERCOM_APP_KEY'),
+    'access_token' => env('INTERCOM_ACCESS_TOKEN'),
 ];

--- a/src/IntercomServiceProvider.php
+++ b/src/IntercomServiceProvider.php
@@ -42,10 +42,9 @@ class IntercomServiceProvider extends ServiceProvider
         );
 
         $this->app->singleton('intercom', function ($app) {
-            $appID = $app['config']->get('intercom.app_id');
-            $apiKey = $app['config']->get('intercom.api_key');
+            $accessToken = $app['config']->get('intercom.access_token');
 
-            $intercom = new IntercomClient($appID, $apiKey);
+            $intercom = new IntercomClient($accessToken, null);
 
             return new IntercomApi($intercom);
         });


### PR DESCRIPTION
Intercom has [changed](https://developers.intercom.com/docs/personal-access-tokens) their API to utilize Access Tokens.  This branch updates the environment variables to use Access Tokens instead of app id's & keys