### PR TITLE
Give access to IntercomClient methods such as getRateLimitDetails()

### DIFF
--- a/src/IntercomApi.php
+++ b/src/IntercomApi.php
@@ -8,7 +8,7 @@ namespace Darkin1\Intercom;
 class IntercomApi
 {
     /**
-     * @var \Guzzle\Service\Client|IntercomBasicAuthClient
+     * @var \Intercom\IntercomClient
      */
     protected $intercom;
 
@@ -21,13 +21,17 @@ class IntercomApi
     }
 
     /**
-     * @param       $method
-     * @param array $args
+     * @param string $method
+     * @param array  $args
      *
      * @return mixed
      */
     public function __call($method, array $args)
     {
+        if (method_exists($this->intercom, $method)) {
+            return call_user_func_array([$this->intercom, $method], $args);
+        }
+
         return $this->intercom->{$method};
     }
 }


### PR DESCRIPTION
Fixes https://github.com/darkin1/intercom/issues/12

```php
Intercom::users()->update($items);

$headers = Intercom::getRateLimitDetails(); 
```

```
Darkin1\Intercom\Facades\Intercom::getRateLimitDetails()
PHP Notice:  Undefined property: Intercom/IntercomClient::$getRateLimitDetails in ./vendor/darkin1/intercom/src/IntercomApi.php on line 31
```

The facade proxies the "intercom/intercom-php" `IntercomClient` instance but its `__call()` magic method doesn't give access to public methods like `getRateLimitDetails()`.

There currently are no naming conflicts between `IntercomClient` public properties and its methods so this isn't a break change.