### PR TITLE
[2.0] Fix deferrable provider in Laravel 5.8+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,12 +8,20 @@
     "email": "dciesielski87@gmail.com"
   }],
   "require": {
-    "php": ">= 5.6",
-    "intercom/intercom-php"       : "^3.0"
+    "php": ">= 7.1",
+    "intercom/intercom-php": "^3.0",
+    "illuminate/support": "5.8.*|5.9.*"
   },
   "autoload": {
     "psr-4": {
       "Darkin1\\Intercom\\": "src/"
+    }
+  },
+  "extra": {
+    "laravel": {
+      "providers": [
+        "Darkin1\\\\Intercom\\IntercomServiceProvider"
+      ]
     }
   },
   "minimum-stability": "dev"

--- a/src/IntercomServiceProvider.php
+++ b/src/IntercomServiceProvider.php
@@ -4,18 +4,11 @@ namespace Darkin1\Intercom;
 
 use Intercom\IntercomClient;
 use Darkin1\Intercom\Facades\Intercom;
-use Illuminate\Support\Facades\Config;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Contracts\Support\DeferrableProvider;
 
-class IntercomServiceProvider extends ServiceProvider
+class IntercomServiceProvider extends ServiceProvider implements DeferrableProvider
 {
-    /**
-     * Indicates if loading of the provider is deferred.
-     *
-     * @var bool
-     */
-    protected $defer = true;
-
     /**
      * Bootstrap the application events.
      *


### PR DESCRIPTION
Laravel has dropped `$defer = true` in favour of service providers implementing a `DeferrableProvider` contract. For Laravel 5.8 apps using this package, it's currently registered every HTTP request and console command even when Intercom is never referenced.

* add `DeferrableProvider` contract
  * https://laravel.com/docs/5.8/upgrade#upgrade-5.8.0
* add package auto-discovery available since Laravel 5.5
  * https://laravel.com/docs/5.8/packages#package-discovery

This should probably be tagged as 2.0 since it removes PHP 5.6 and PHP 7.0 support.

"intercom/intercom-php" also drops < PHP 7.1 support in its ^4.0 releases: https://github.com/intercom/intercom-php/releases