### PR TITLE
Bump "intercom/intercom-php" to 4.0.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,9 @@
   }],
   "require": {
     "php": ">= 7.1",
-    "intercom/intercom-php": "^3.0",
-    "illuminate/support": "5.8.*|5.9.*"
+    "intercom/intercom-php": "^4.0",
+    "illuminate/support": "5.8.*|5.9.*",
+    "php-http/guzzle6-adapter": "^2.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
## Intercom 4.0 update

With the recently-merged Laravel 5.8 service provider fixes requiring PHP 7.1+, "intercom/intercom-php" can now be bumped to ^4.0 that was released January 2019. This release adds a dependency on virtual package "php-http/client-implementation" so it's no longer locked into Guzzle 6 HTTP client to curl Intercom's API.

From: https://github.com/intercom/intercom-php/blob/master/README.md

> This library uses HTTPlug as HTTP client. HTTPlug is an abstraction that allows this library to support many different HTTP Clients. Therefore, you need to provide it with an adapter for the HTTP library you prefer. You can find all the available adapters in Packagist. This documentation assumes you use the Guzzle6 Client, but you can replace it with any adapter that you prefer.
> 
> The recommended way to install intercom-php is through Composer:
> 
> ```sh
> composer require intercom/intercom-php php-http/guzzle6-adapter
> ```

## Composer dependency changes

So the choice here is to either:

1. put the same above instructions in this package's readme.md, along with updating composer.json

   ```json
   {
       "suggest": {
           "php-http/guzzle6-adapter": "The preferred HTTP client for \"intercom/intercom-php\" calls to Intercom's API."
       }
   }
   ````
2. Make this package opinionated, always installing concrete package "php-http/guzzle6-adapter" to fulfill the virtual "php-http/client-implementation" requirement since Laravel 5.8+ has "guzzlehttp/guzzle ^6.0" as a suggested dependency.

This pull request chooses option 2. The current 1.0.7 tag for "intercom/intercom-php" ^3.0 already uses Guzzle 6 for HTTP calls.

## Laravel package breaking changes

4.0.0 release notes: https://github.com/intercom/intercom-php/releases/tag/v4.0.0

"darkin1/intercom" 1.0.7 didn't expose the base `IntercomClient` instance via the `Darkin1\Intercom\IntercomApi` class proxy so there are **no breaking changes**.