### PR TITLE
Configurable API version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .idea/
+/vendor
+composer.lock

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Change your default settings in `app/config/intercom.php`:
 <?php
 return [
     'access_token' => env('INTERCOM_ACCESS_TOKEN', '****'),
+    'api_version' => env('INTERCOM_API_VERSION', '1.1'),
 ];
 ```
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ return [
 ];
 ```
 
+Review the official docs to see the list of [available intercom api versions](https://developers.intercom.com/intercom-api-reference/reference)
 
 Example
 -------------

--- a/config/intercom.php
+++ b/config/intercom.php
@@ -2,4 +2,5 @@
 
 return [
     'access_token' => env('INTERCOM_ACCESS_TOKEN'),
+    'api_version' => env('INTERCOM_API_VERSION'),
 ];

--- a/src/IntercomServiceProvider.php
+++ b/src/IntercomServiceProvider.php
@@ -37,7 +37,9 @@ class IntercomServiceProvider extends ServiceProvider implements DeferrableProvi
         $this->app->singleton('intercom', function ($app) {
             $accessToken = $app['config']->get('intercom.access_token');
 
-            $intercom = new IntercomClient($accessToken, null);
+            $intercom = new IntercomClient($accessToken, null, [
+                'Intercom-Version' => $app['config']->get('intercom.api_version')
+            ]);
 
             return new IntercomApi($intercom);
         });


### PR DESCRIPTION
We still use 1.1 and 1.4 intercom API versions in some of our apps, so I make a small modification to allow developers to change the intercom API version easily.