### PR TITLE
Added laravel 8 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Intercom
 [![StyleCI](https://styleci.io/repos/54785593/shield?branch=master)](https://styleci.io/repos/54785593)
 [![Build Status](https://travis-ci.org/darkin1/intercom.svg?branch=master)](https://travis-ci.org/darkin1/intercom)
 
-Wrapper on the Intercom class provided by Intercom  - with support for Laravel 5.x, 6.x, 7.x
+Wrapper on the Intercom class provided by Intercom  - with support for Laravel 5.x, 6.x, 7.x, 8.x
 
 Installation
 ------------

--- a/composer.json
+++ b/composer.json
@@ -8,10 +8,10 @@
     "email": "dciesielski87@gmail.com"
   }],
   "require": {
-    "php": ">= 7.1",
+    "php": ">= 7.3",
     "intercom/intercom-php": "^4.0",
-    "illuminate/support": "^5.8|^6.0|^7.0",
-    "php-http/guzzle6-adapter": "^2.0"
+    "illuminate/support": "^5.8|^6.0|^7.0|^8.0",
+    "guzzlehttp/psr7": "^1.7.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
- Added laravel 8 compatibility
- Minimum PHP to 7.3 since 7.1 and 7.2 are not maintained
- Guzzle 7

Should be a major release since changes are breaking.